### PR TITLE
Vanilla gadget updates

### DIFF
--- a/DS Gadget/MainForm Tabs/GadgetTabItems.cs
+++ b/DS Gadget/MainForm Tabs/GadgetTabItems.cs
@@ -28,6 +28,8 @@ namespace DS_Gadget
             foreach (DSItem item in category.Items)
                 lbxItems.Items.Add(item);
             lbxItems.SelectedIndex = 0;
+            searchBox.Text = "";
+            lblSearch.Visible = true;
         }
 
         private void searchBox_TextChanged(object sender, EventArgs e)

--- a/DS Gadget/MainForm Tabs/GadgetTabMisc.cs
+++ b/DS Gadget/MainForm Tabs/GadgetTabMisc.cs
@@ -45,6 +45,8 @@ namespace DS_Gadget
             foreach (DSItem item in category.Items)
                 lbxItems.Items.Add(item);
             lbxItems.SelectedIndex = 0;
+            searchBox.Text = "";
+            lblSearch.Visible = true;
         }
 
         private void searchBox_TextChanged(object sender, EventArgs e)

--- a/DS Gadget/MainForm Tabs/GadgetTabPlayer.cs
+++ b/DS Gadget/MainForm Tabs/GadgetTabPlayer.cs
@@ -240,6 +240,7 @@ namespace DS_Gadget
                 {
                     result = new DSBonfire(bonfireID, $"Unknown: {bonfireID}");
                     cbxBonfire.Items.Add(result);
+                    DSBonfire.All.Add(result);
                 }
                 cbxBonfire.SelectedItem = result;
             }

--- a/DS Gadget/MainForm Tabs/GadgetTabPlayer.cs
+++ b/DS Gadget/MainForm Tabs/GadgetTabPlayer.cs
@@ -43,6 +43,7 @@ namespace DS_Gadget
         private void searchBox_TextChanged(object sender, EventArgs e)
         {
             cbxBonfire.Items.Clear();
+            cbxBonfire.SelectedItem = null;
             foreach (DSBonfire bonfire in DSBonfire.All)
             {
                 if (bonfire.ToString().ToLower().Contains(searchBox.Text.ToLower()))
@@ -52,8 +53,10 @@ namespace DS_Gadget
 
             }
 
-            if (cbxBonfire.Items.Count > 0)
-                cbxBonfire.SelectedIndex = 0;
+            if (cbxBonfire.Items.Count < 1)
+                cbxBonfire.Items.Add(DSBonfire.All[0]);
+
+            cbxBonfire.SelectedIndex = 0;
 
             if (searchBox.Text == "")
                 lblSearch.Visible = true;

--- a/DS Gadget/MainForm Tabs/GadgetTabStats.cs
+++ b/DS Gadget/MainForm Tabs/GadgetTabStats.cs
@@ -39,9 +39,7 @@ namespace DS_Gadget
         {
             txtSoulLevel.Text = Hook.SoulLevel.ToString();
             nudHumanity.Value = Hook.Humanity;
-            nudHumanity.Text = Hook.Humanity.ToString();
             nudSouls.Value = Hook.Souls;
-            nudSouls.Text = Hook.Souls.ToString();
             try
             {
                 Updating = true;
@@ -65,19 +63,12 @@ namespace DS_Gadget
                     .FirstOrDefault(c => c.ID == Hook.Covenant);
             }
             nudCovChaos.Value = Hook.ChaosServantPoints;
-            nudCovChaos.Text = Hook.ChaosServantPoints.ToString();
             nudCovDarkmoon.Value = Hook.DarkmoonBladePoints;
-            nudCovDarkmoon.Text = Hook.DarkmoonBladePoints.ToString();
             nudCovDarkwraith.Value = Hook.DarkwraithPoints;
-            nudCovDarkwraith.Text = Hook.DarkwraithPoints.ToString();
             nudCovDragon.Value = Hook.PathOfTheDragonPoints;
-            nudCovDragon.Text = Hook.PathOfTheDragonPoints.ToString();
             nudCovForest.Value = Hook.ForestHunterPoints;
-            nudCovForest.Text = Hook.ForestHunterPoints.ToString();
             nudCovGravelord.Value = Hook.GravelordServantPoints;
-            nudCovGravelord.Text = Hook.GravelordServantPoints.ToString();
             nudCovSunlight.Value = Hook.WarriorOfSunlightPoints;
-            nudCovSunlight.Text = Hook.WarriorOfSunlightPoints.ToString();
         }
 
         private void RecalculateStats()
@@ -122,6 +113,25 @@ namespace DS_Gadget
                         LoadSavedStats();
                     }
                 }
+                if(nudHumanity.Text == "")
+                    nudHumanity.Text = Hook.Humanity.ToString();
+                if (nudSouls.Text == "")
+                    nudSouls.Text = Hook.Souls.ToString();
+                if (nudCovChaos.Text == "")
+                    nudCovChaos.Text = Hook.ChaosServantPoints.ToString();
+                if (nudCovDarkmoon.Text == "")
+                    nudCovDarkmoon.Text = Hook.DarkmoonBladePoints.ToString();
+                if (nudCovDarkwraith.Text == "")
+                    nudCovDarkwraith.Text = Hook.DarkwraithPoints.ToString();
+                if (nudCovForest.Text == "")
+                    nudCovForest.Text = Hook.ForestHunterPoints.ToString();
+                if (nudCovGravelord.Text == "")
+                    nudCovGravelord.Text = Hook.GravelordServantPoints.ToString();
+                if (nudCovDragon.Text == "")
+                    nudCovDragon.Text = Hook.PathOfTheDragonPoints.ToString();
+                if (nudCovSunlight.Text == "")
+                    nudCovSunlight.Text = Hook.WarriorOfSunlightPoints.ToString();
+
             }
             else
             {

--- a/DS Gadget/MainForm Tabs/GadgetTabStats.cs
+++ b/DS Gadget/MainForm Tabs/GadgetTabStats.cs
@@ -295,29 +295,73 @@ namespace DS_Gadget
             var stat = sender as System.Windows.Forms.NumericUpDown;
             switch (stat.Name)
             {
+                case "nudHumanity":
+                    SavedStats.Humanity = nudHumanity.Value;
+                    nudHumanity.Text = nudHumanity.Value.ToString();
+                    break;
+                case "nudSouls":
+                    SavedStats.Souls = nudSouls.Value;
+                    nudSouls.Text = nudSouls.Value.ToString();
+                    break;
                 case "nudVit":
-                    SavedStats.Vit = nudVit.Value;
+                    SavedStats.Vit = Clamp(nudVit.Value, 1, 99);
+                    nudVit.Text = SavedStats.Vit.Value.ToString();
                     break;
                 case "nudAtt":
-                    SavedStats.Att = nudAtt.Value;
+                    SavedStats.Att = Clamp(nudAtt.Value, 1, 99);
+                    nudAtt.Text = SavedStats.Att.Value.ToString();
                     break;
                 case "nudEnd":
-                    SavedStats.End = nudEnd.Value;
+                    SavedStats.End = Clamp(nudEnd.Value, 1, 99);
+                    nudEnd.Text = SavedStats.End.Value.ToString();
                     break;
                 case "nudStr":
-                    SavedStats.Str = nudStr.Value;
+                    SavedStats.Str = Clamp(nudStr.Value, 1, 99);
+                    nudStr.Text = SavedStats.Str.Value.ToString();
                     break;
                 case "nudDex":
-                    SavedStats.Dex = nudDex.Value;
+                    SavedStats.Dex = Clamp(nudDex.Value, 1, 99);
+                    nudDex.Text = SavedStats.Dex.Value.ToString();
                     break;
                 case "nudRes":
-                    SavedStats.Res = nudRes.Value;
+                    SavedStats.Res = Clamp(nudRes.Value, 1, 99);
+                    nudRes.Text = SavedStats.Res.Value.ToString();
                     break;
                 case "nudInt":
-                    SavedStats.Int = nudInt.Value;
+                    SavedStats.Int = Clamp(nudInt.Value, 1, 99);
+                    nudInt.Text = SavedStats.Int.Value.ToString();
                     break;
                 case "nudFth":
-                    SavedStats.Fth = nudFth.Value;
+                    SavedStats.Fth = Clamp(nudFth.Value, 1, 99);
+                    nudFth.Text = SavedStats.Fth.Value.ToString();
+                    break;
+                case "nudCovChaos":
+                    SavedStats.CovChaos = nudCovChaos.Value;
+                    nudCovChaos.Text = nudCovChaos.Value.ToString();
+                    break;
+                case "nudCovDarkmoon":
+                    SavedStats.CovDarkmoon = nudCovDarkmoon.Value;
+                    nudCovDarkmoon.Text = nudCovDarkmoon.Value.ToString();
+                    break;
+                case "nudCovDarkwraith":
+                    SavedStats.CovDarkwraith = nudCovDarkwraith.Value;
+                    nudCovDarkwraith.Text = nudCovDarkwraith.Value.ToString();
+                    break;
+                case "nudCovForest":
+                    SavedStats.CovForest = nudCovForest.Value;
+                    nudCovForest.Text = nudCovForest.Value.ToString();
+                    break;
+                case "nudCovGravelord":
+                    SavedStats.CovGravelord = nudCovGravelord.Value;
+                    nudCovGravelord.Text = nudCovGravelord.Value.ToString();
+                    break;
+                case "nudCovDragon":
+                    SavedStats.CovDragon = nudCovDragon.Value;
+                    nudCovDragon.Text = nudCovDragon.Value.ToString();
+                    break;
+                case "nudCovSunlight":
+                    SavedStats.CovSunlight = nudCovSunlight.Value;
+                    nudCovSunlight.Text = nudCovSunlight.Value.ToString();
                     break;
                 default:
                     break;
@@ -655,172 +699,102 @@ namespace DS_Gadget
                 if (e.KeyCode == System.Windows.Forms.Keys.Enter)
                 {
                     SaveStats(sender);
-                    var stat = sender as System.Windows.Forms.NumericUpDown;
-                    switch (stat.Name)
-                    {
-                        case "nudHumanity":
-                            SavedStats.Humanity = nudHumanity.Value;
-                            nudHumanity.Text = nudHumanity.Value.ToString();
-                            break;
-                        case "nudSouls":
-                            SavedStats.Souls = nudSouls.Value;
-                            nudSouls.Text = nudSouls.Value.ToString();
-                            break;
-                        case "nudVit":
-                            SavedStats.Vit = Clamp(nudVit.Value, 1, 99);
-                            nudVit.Text = SavedStats.Vit.Value.ToString();
-                            break;
-                        case "nudAtt":
-                            SavedStats.Att = Clamp(nudAtt.Value, 1, 99);
-                            nudAtt.Text = SavedStats.Att.Value.ToString();
-                            break;
-                        case "nudEnd":
-                            SavedStats.End = Clamp(nudEnd.Value, 1, 99);
-                            nudEnd.Text = SavedStats.End.Value.ToString();
-                            break;
-                        case "nudStr":
-                            SavedStats.Str = Clamp(nudStr.Value, 1, 99);
-                            nudStr.Text = SavedStats.Str.Value.ToString();
-                            break;
-                        case "nudDex":
-                            SavedStats.Dex = Clamp(nudDex.Value, 1, 99);
-                            nudDex.Text = SavedStats.Dex.Value.ToString();
-                            break;
-                        case "nudRes":
-                            SavedStats.Res = Clamp(nudRes.Value, 1, 99);
-                            nudRes.Text = SavedStats.Res.Value.ToString();
-                            break;
-                        case "nudInt":
-                            SavedStats.Int = Clamp(nudInt.Value, 1, 99);
-                            nudInt.Text = SavedStats.Int.Value.ToString();
-                            break;
-                        case "nudFth":
-                            SavedStats.Fth = Clamp(nudFth.Value, 1, 99);
-                            nudFth.Text = SavedStats.Fth.Value.ToString();
-                            break;
-                        case "nudCovChaos":
-                            SavedStats.CovChaos = nudCovChaos.Value;
-                            nudCovChaos.Text = nudCovChaos.Value.ToString();
-                            break;
-                        case "nudCovDarkmoon":
-                            SavedStats.CovDarkmoon = nudCovDarkmoon.Value;
-                            nudCovDarkmoon.Text = nudCovDarkmoon.Value.ToString();
-                            break;
-                        case "nudCovDarkwraith":
-                            SavedStats.CovDarkwraith = nudCovDarkwraith.Value;
-                            nudCovDarkwraith.Text = nudCovDarkwraith.Value.ToString();
-                            break;
-                        case "nudCovForest":
-                            SavedStats.CovForest = nudCovForest.Value;
-                            nudCovForest.Text = nudCovForest.Value.ToString();
-                            break;
-                        case "nudCovGravelord":
-                            SavedStats.CovGravelord = nudCovGravelord.Value;
-                            nudCovGravelord.Text = nudCovGravelord.Value.ToString();
-                            break;
-                        case "nudCovDragon":
-                            SavedStats.CovDragon = nudCovDragon.Value;
-                            nudCovDragon.Text = nudCovDragon.Value.ToString();
-                            break;
-                        case "nudCovSunlight":
-                            SavedStats.CovSunlight = nudCovSunlight.Value;
-                            nudCovSunlight.Text = nudCovSunlight.Value.ToString();
-                            break;
-                        default:
-                            break;
-                    }
-                    
                 }
 
                 if (e.KeyCode == System.Windows.Forms.Keys.Escape)
                 {
-                    var stat = sender as System.Windows.Forms.NumericUpDown;
-                    switch (stat.Name)
-                    {
-                        case "nudHumanity":
-                            nudHumanity.Value = 0;
-                            nudHumanity.Text = "";
-                            SavedStats.Humanity = null;
-                            break;
-                        case "nudSouls":
-                            nudSouls.Value = 0;
-                            nudSouls.Text = "";
-                            SavedStats.Souls = null;
-                            break;
-                        case "nudVit":
-                            nudVit.Value = 0;
-                            nudVit.Text = "";
-                            SavedStats.Vit = null;
-                            break;
-                        case "nudAtt":
-                            nudAtt.Value = 0;
-                            nudAtt.Text = "";
-                            SavedStats.Att = null;
-                            break;
-                        case "nudEnd":
-                            nudEnd.Value = 0;
-                            nudEnd.Text = "";
-                            SavedStats.End = null;
-                            break;
-                        case "nudStr":
-                            nudStr.Value = 0;
-                            nudStr.Text = "";
-                            SavedStats.Str = null;
-                            break;
-                        case "nudDex":
-                            nudDex.Value = 0;
-                            nudDex.Text = "";
-                            SavedStats.Dex = null;
-                            break;
-                        case "nudRes":
-                            nudRes.Value = 0;
-                            nudRes.Text = "";
-                            SavedStats.Res = null;
-                            break;
-                        case "nudInt":
-                            nudInt.Value = 0;
-                            nudInt.Text = "";
-                            SavedStats.Int = null;
-                            break;
-                        case "nudFth":
-                            nudFth.Value = 0;
-                            nudFth.Text = "";
-                            SavedStats.Fth = null;
-                            break;
-                        case "nudCovChaos":
-                            nudCovChaos.Text = "";
-                            SavedStats.CovChaos = null;
-                            break;
-                        case "nudCovDarkmoon":
-                            nudCovDarkmoon.Text = "";
-                            SavedStats.CovDarkmoon = null;
-                            break;
-                        case "nudCovDarkwraith":
-                            nudCovDarkwraith.Text = "";
-                            SavedStats.CovDarkwraith = null;
-                            break;
-                        case "nudCovForest":
-                            nudCovForest.Text = "";
-                            SavedStats.CovForest = null;
-                            break;
-                        case "nudCovGravelord":
-                            nudCovGravelord.Text = "";
-                            SavedStats.CovGravelord = null;
-                            break;
-                        case "nudCovDragon":
-                            nudCovDragon.Text = "";
-                            SavedStats.CovDragon = null;
-                            break;
-                        case "nudCovSunlight":
-                            nudCovSunlight.Text = "";
-                            SavedStats.CovSunlight = null;
-                            break;
-                        default:
-                            break;
-                    }
+                    NullStat(sender);
                 }
             }
 
+        }
+
+        private void NullStat(object sender)
+        {
+            var stat = sender as System.Windows.Forms.NumericUpDown;
+            switch (stat.Name)
+            {
+                case "nudHumanity":
+                    nudHumanity.Value = 0;
+                    nudHumanity.Text = "";
+                    SavedStats.Humanity = null;
+                    break;
+                case "nudSouls":
+                    nudSouls.Value = 0;
+                    nudSouls.Text = "";
+                    SavedStats.Souls = null;
+                    break;
+                case "nudVit":
+                    nudVit.Value = 0;
+                    nudVit.Text = "";
+                    SavedStats.Vit = null;
+                    break;
+                case "nudAtt":
+                    nudAtt.Value = 0;
+                    nudAtt.Text = "";
+                    SavedStats.Att = null;
+                    break;
+                case "nudEnd":
+                    nudEnd.Value = 0;
+                    nudEnd.Text = "";
+                    SavedStats.End = null;
+                    break;
+                case "nudStr":
+                    nudStr.Value = 0;
+                    nudStr.Text = "";
+                    SavedStats.Str = null;
+                    break;
+                case "nudDex":
+                    nudDex.Value = 0;
+                    nudDex.Text = "";
+                    SavedStats.Dex = null;
+                    break;
+                case "nudRes":
+                    nudRes.Value = 0;
+                    nudRes.Text = "";
+                    SavedStats.Res = null;
+                    break;
+                case "nudInt":
+                    nudInt.Value = 0;
+                    nudInt.Text = "";
+                    SavedStats.Int = null;
+                    break;
+                case "nudFth":
+                    nudFth.Value = 0;
+                    nudFth.Text = "";
+                    SavedStats.Fth = null;
+                    break;
+                case "nudCovChaos":
+                    nudCovChaos.Text = "";
+                    SavedStats.CovChaos = null;
+                    break;
+                case "nudCovDarkmoon":
+                    nudCovDarkmoon.Text = "";
+                    SavedStats.CovDarkmoon = null;
+                    break;
+                case "nudCovDarkwraith":
+                    nudCovDarkwraith.Text = "";
+                    SavedStats.CovDarkwraith = null;
+                    break;
+                case "nudCovForest":
+                    nudCovForest.Text = "";
+                    SavedStats.CovForest = null;
+                    break;
+                case "nudCovGravelord":
+                    nudCovGravelord.Text = "";
+                    SavedStats.CovGravelord = null;
+                    break;
+                case "nudCovDragon":
+                    nudCovDragon.Text = "";
+                    SavedStats.CovDragon = null;
+                    break;
+                case "nudCovSunlight":
+                    nudCovSunlight.Text = "";
+                    SavedStats.CovSunlight = null;
+                    break;
+                default:
+                    break;
+            }
         }
 
         private void txtName_KeyDown(object sender, System.Windows.Forms.KeyEventArgs e)
@@ -842,29 +816,34 @@ namespace DS_Gadget
             {
                 if (e.KeyCode == System.Windows.Forms.Keys.Escape)
                 {
-                    var cmb = sender as System.Windows.Forms.ComboBox;
-                    switch (cmb.Name)
-                    {
-                        case "cmbSex":
-                            cmbSex.SelectedIndex = -1;
-                            SavedStats.Sex = null;
-                            break;
-                        case "cmbClass":
-                            cmbClass.SelectedIndex = -1;
-                            SavedStats.Class = null;
-                            break;
-                        case "cmbPhysique":
-                            cmbPhysique.SelectedIndex = -1;
-                            SavedStats.Physique = null;
-                            break;
-                        case "cmbCovenant":
-                            cmbCovenant.SelectedIndex = -1;
-                            SavedStats.Covenant = null;
-                            break;
-                        default:
-                            break;
-                    }
+                    cmbNull(sender);
                 }
+            }
+        }
+
+        private void cmbNull(object sender)
+        {
+            var cmb = sender as System.Windows.Forms.ComboBox;
+            switch (cmb.Name)
+            {
+                case "cmbSex":
+                    cmbSex.SelectedIndex = -1;
+                    SavedStats.Sex = null;
+                    break;
+                case "cmbClass":
+                    cmbClass.SelectedIndex = -1;
+                    SavedStats.Class = null;
+                    break;
+                case "cmbPhysique":
+                    cmbPhysique.SelectedIndex = -1;
+                    SavedStats.Physique = null;
+                    break;
+                case "cmbCovenant":
+                    cmbCovenant.SelectedIndex = -1;
+                    SavedStats.Covenant = null;
+                    break;
+                default:
+                    break;
             }
         }
     }

--- a/DS Gadget/MainForm Tabs/GadgetTabStats.cs
+++ b/DS Gadget/MainForm Tabs/GadgetTabStats.cs
@@ -39,7 +39,9 @@ namespace DS_Gadget
         {
             txtSoulLevel.Text = Hook.SoulLevel.ToString();
             nudHumanity.Value = Hook.Humanity;
+            nudHumanity.Text = Hook.Humanity.ToString();
             nudSouls.Value = Hook.Souls;
+            nudSouls.Text = Hook.Souls.ToString();
             try
             {
                 Updating = true;
@@ -63,13 +65,19 @@ namespace DS_Gadget
                     .FirstOrDefault(c => c.ID == Hook.Covenant);
             }
             nudCovChaos.Value = Hook.ChaosServantPoints;
+            nudCovChaos.Text = Hook.ChaosServantPoints.ToString();
             nudCovDarkmoon.Value = Hook.DarkmoonBladePoints;
+            nudCovDarkmoon.Text = Hook.DarkmoonBladePoints.ToString();
             nudCovDarkwraith.Value = Hook.DarkwraithPoints;
+            nudCovDarkwraith.Text = Hook.DarkwraithPoints.ToString();
             nudCovDragon.Value = Hook.PathOfTheDragonPoints;
+            nudCovDragon.Text = Hook.PathOfTheDragonPoints.ToString();
             nudCovForest.Value = Hook.ForestHunterPoints;
+            nudCovForest.Text = Hook.ForestHunterPoints.ToString();
             nudCovGravelord.Value = Hook.GravelordServantPoints;
+            nudCovGravelord.Text = Hook.GravelordServantPoints.ToString();
             nudCovSunlight.Value = Hook.WarriorOfSunlightPoints;
-
+            nudCovSunlight.Text = Hook.WarriorOfSunlightPoints.ToString();
         }
 
         private void RecalculateStats()
@@ -587,31 +595,31 @@ namespace DS_Gadget
             nudHumanity.Text = "";
             nudSouls.Value = 0;
             nudSouls.Text = "";
-            txtSoulLevel.Text = "";
-            nudVit.Minimum = 1;
-            nudVit.Value = 1;
+            nudVit.Minimum = 0;
+            nudVit.Value = 0;
             nudVit.Text = "";
-            nudAtt.Minimum = 1;
-            nudAtt.Value = 1;
+            nudAtt.Minimum = 0;
+            nudAtt.Value = 0;
             nudAtt.Text = "";
-            nudEnd.Minimum = 1;
-            nudEnd.Value = 1;
+            nudEnd.Minimum = 0;
+            nudEnd.Value = 0;
             nudEnd.Text = "";
-            nudStr.Minimum = 1;
-            nudStr.Value = 1;
+            nudStr.Minimum = 0;
+            nudStr.Value = 0;
             nudStr.Text = "";
-            nudDex.Minimum = 1;
-            nudDex.Value = 1;
+            nudDex.Minimum = 0;
+            nudDex.Value = 0;
             nudDex.Text = "";
-            nudRes.Minimum = 1;
-            nudRes.Value = 1;
+            nudRes.Minimum = 0;
+            nudRes.Value = 0;
             nudRes.Text = "";
-            nudInt.Minimum = 1;
-            nudInt.Value = 1;
+            nudInt.Minimum = 0;
+            nudInt.Value = 0;
             nudInt.Text = "";
-            nudFth.Minimum = 1;
-            nudFth.Value = 1;
+            nudFth.Minimum = 0;
+            nudFth.Value = 0;
             nudFth.Text = "";
+            txtSoulLevel.Text = "";
             cmbCovenant.SelectedIndex = -1;
             nudCovChaos.Value = 0;
             nudCovChaos.Text = "";
@@ -649,36 +657,36 @@ namespace DS_Gadget
                             nudSouls.Text = nudSouls.Value.ToString();
                             break;
                         case "nudVit":
-                            SavedStats.Vit = nudVit.Value;
-                            nudVit.Text = nudVit.Value.ToString();
+                            SavedStats.Vit = Clamp(nudVit.Value, 1, 99);
+                            nudVit.Text = SavedStats.Vit.Value.ToString();
                             break;
                         case "nudAtt":
-                            SavedStats.Att = nudAtt.Value;
-                            nudAtt.Text = nudAtt.Value.ToString();
+                            SavedStats.Att = Clamp(nudAtt.Value, 1, 99);
+                            nudAtt.Text = SavedStats.Att.Value.ToString();
                             break;
                         case "nudEnd":
-                            SavedStats.End = nudEnd.Value;
-                            nudEnd.Text = nudEnd.Value.ToString();
+                            SavedStats.End = Clamp(nudEnd.Value, 1, 99);
+                            nudEnd.Text = SavedStats.End.Value.ToString();
                             break;
                         case "nudStr":
-                            SavedStats.Str = nudStr.Value;
-                            nudStr.Text = nudStr.Value.ToString();
+                            SavedStats.Str = Clamp(nudStr.Value, 1, 99);
+                            nudStr.Text = SavedStats.Str.Value.ToString();
                             break;
                         case "nudDex":
-                            SavedStats.Dex = nudDex.Value;
-                            nudDex.Text = nudDex.Value.ToString();
+                            SavedStats.Dex = Clamp(nudDex.Value, 1, 99);
+                            nudDex.Text = SavedStats.Dex.Value.ToString();
                             break;
                         case "nudRes":
-                            SavedStats.Res = nudRes.Value;
-                            nudRes.Text = nudRes.Value.ToString();
+                            SavedStats.Res = Clamp(nudRes.Value, 1, 99);
+                            nudRes.Text = SavedStats.Res.Value.ToString();
                             break;
                         case "nudInt":
-                            SavedStats.Int = nudInt.Value;
-                            nudInt.Text = nudInt.Value.ToString();
+                            SavedStats.Int = Clamp(nudInt.Value, 1, 99);
+                            nudInt.Text = SavedStats.Int.Value.ToString();
                             break;
                         case "nudFth":
-                            SavedStats.Fth = nudFth.Value;
-                            nudFth.Text = nudFth.Value.ToString();
+                            SavedStats.Fth = Clamp(nudFth.Value, 1, 99);
+                            nudFth.Text = SavedStats.Fth.Value.ToString();
                             break;
                         case "nudCovChaos":
                             SavedStats.CovChaos = nudCovChaos.Value;
@@ -720,42 +728,52 @@ namespace DS_Gadget
                     switch (stat.Name)
                     {
                         case "nudHumanity":
+                            nudHumanity.Value = 0;
                             nudHumanity.Text = "";
                             SavedStats.Humanity = null;
                             break;
                         case "nudSouls":
+                            nudSouls.Value = 0;
                             nudSouls.Text = "";
                             SavedStats.Souls = null;
                             break;
                         case "nudVit":
+                            nudVit.Value = 0;
                             nudVit.Text = "";
                             SavedStats.Vit = null;
                             break;
                         case "nudAtt":
+                            nudAtt.Value = 0;
                             nudAtt.Text = "";
                             SavedStats.Att = null;
                             break;
                         case "nudEnd":
+                            nudEnd.Value = 0;
                             nudEnd.Text = "";
                             SavedStats.End = null;
                             break;
                         case "nudStr":
+                            nudStr.Value = 0;
                             nudStr.Text = "";
                             SavedStats.Str = null;
                             break;
                         case "nudDex":
+                            nudDex.Value = 0;
                             nudDex.Text = "";
                             SavedStats.Dex = null;
                             break;
                         case "nudRes":
+                            nudRes.Value = 0;
                             nudRes.Text = "";
                             SavedStats.Res = null;
                             break;
                         case "nudInt":
+                            nudInt.Value = 0;
                             nudInt.Text = "";
                             SavedStats.Int = null;
                             break;
                         case "nudFth":
+                            nudFth.Value = 0;
                             nudFth.Text = "";
                             SavedStats.Fth = null;
                             break;


### PR DESCRIPTION
Fixed a bug with bonfires where it would display your last selected bonfire, but as an error message, when the search box had no results to show

Updated stats so that they show correctly when loading in to a character with 0 humanity/souls/covenant stats

Fixed bug with escape not showing the search text after clearing the search box.

Will work on that performance test soon.